### PR TITLE
Add basic React Native app

### DIFF
--- a/MyReactNativeApp/.gitignore
+++ b/MyReactNativeApp/.gitignore
@@ -1,0 +1,14 @@
+# Node modules
+node_modules/
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+# Metro
+.expo/
+# Android build
+android/
+# iOS build
+ios/
+# IDE
+.vscode/

--- a/MyReactNativeApp/App.js
+++ b/MyReactNativeApp/App.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import {SafeAreaView, Text, StyleSheet} from 'react-native';
+
+function App() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.text}>Hello, React Native!</Text>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 20,
+  },
+});
+
+export default App;

--- a/MyReactNativeApp/README.md
+++ b/MyReactNativeApp/README.md
@@ -1,0 +1,13 @@
+# MyReactNativeApp
+
+This is a simple React Native application initialized without dependencies.
+
+To get started:
+
+```bash
+cd MyReactNativeApp
+npm install
+npm run start
+```
+
+You can run the app on Android using `npm run android` or on iOS with `npm run ios` (macOS only).

--- a/MyReactNativeApp/app.json
+++ b/MyReactNativeApp/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "MyReactNativeApp",
+  "displayName": "MyReactNativeApp"
+}

--- a/MyReactNativeApp/index.js
+++ b/MyReactNativeApp/index.js
@@ -1,0 +1,5 @@
+import {AppRegistry} from 'react-native';
+import App from './App';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/MyReactNativeApp/package.json
+++ b/MyReactNativeApp/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "MyReactNativeApp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios"
+  },
+  "dependencies": {
+    "react": "19.1.0",
+    "react-native": "0.80.1"
+  },
+  "devDependencies": {
+    "react-test-renderer": "19.1.0"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # NamurAuto
+
+This repository contains a sample React Native application located in the `MyReactNativeApp` directory. You can install dependencies and start the Metro bundler using:
+
+```bash
+cd MyReactNativeApp
+npm install
+npm run start
+```


### PR DESCRIPTION
## Summary
- add a React Native sample app under `MyReactNativeApp`
- document how to start the app

## Testing
- `npm view react-native version`


------
https://chatgpt.com/codex/tasks/task_e_686ebfb1ff60833094a22d69c7946bc1